### PR TITLE
Fetch env undefined variable fix

### DIFF
--- a/checkout-tag.yml
+++ b/checkout-tag.yml
@@ -1,5 +1,5 @@
 # Usage
-# ansible-playbook checkout-tag.yml -e -tag=<git tag>
+# ansible-playbook checkout-tag.yml -e tag=<git tag>
 #  note: tag is required
 
 - name: checkout-tag.yml

--- a/deploy-application-environment-file.sh
+++ b/deploy-application-environment-file.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script will:
+# - Pull the latest env.php file from the config repo
+# - Push this env.php to all nodes
+# - Import the new config
+
+ansible-playbook fetch-application-environment-configuration.yml
+ansible-playbook deploy-application-environment-file.yml
+ansible-playbook deploy-config.yml

--- a/fetch-application-environment-configuration.yml
+++ b/fetch-application-environment-configuration.yml
@@ -34,19 +34,31 @@
 
     - name: "Playbook - Cleaning up target dir for application config deployment"
       command: "rm -rf /tmp/application_config"
+      register: shell_result
+
+    - name: "Playbook - Shell Standard Error"
+      debug:
+        var: shell_result.stderr
 
     - name: "Playbook - fetch application config from Git"
       command: "git clone {{ ansible_local.custom.general.git_config_repository }} /tmp/application_config"
+      register: shell_result
+
+    - name: "Playbook - Shell Standard Error"
+      debug:
+        var: shell_result.stderr
 
     - name: "Playbook - prepare dir"
       command: "mkdir /tmp/application_config/current"
+      register: shell_result
+
+    - name: "Playbook - Shell Standard Error"
+      debug:
+        var: shell_result.stderr
 
     - name: "Playbook - prepare configuration file"
       command: "cp /tmp/application_config/{{ ansible_local.custom.general.git_config_repository_path }}/env.php /tmp/application_config/current/env.php"
-
-    - name: "Playbook - Shell Standard Output"
-      debug:
-        var: shell_result.stdout_lines
+      register: shell_result
 
     - name: "Playbook - Shell Standard Error"
       debug:


### PR DESCRIPTION
- Fix undefined variable error, because `shell_result` was never being registered in the script.
  - Instead, the script will not output any errors in stderr after each task.
- Add new bash script that fetches the latest env.php, pushes it to all servers, and then run the config import command. This makes it easier to deploy the latest env.php, without having to do a full deploy or run the commands separately by hand.
- Fix usage description in checkout-tags.yaml